### PR TITLE
Use twine --skip-existing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,6 +44,7 @@ stages:
               python.version: '3.8'
         dependsOn: BuildAndTest
         condition: succeeded()
+
         steps:
           - task: UsePythonVersion@0
             inputs:
@@ -52,19 +53,19 @@ stages:
 
           - script: |
               python -m pip install ".[dev]"
-            displayName: 'Install dependencies'
+            displayName: 'Install dev dependencies'            
 
           - script: |
               python -m build
             displayName: 'Build distribution packages'
             condition: succeeded()
 
-          # - task: TwineAuthenticate@1
-          #   displayName: Twine Authenticate
-          #   inputs:
-          #     artifactFeed: p4irin
+          - task: TwineAuthenticate@1
+            displayName: Twine Authenticate
+            inputs:
+              artifactFeed: p4irin
 
-          # - script: |
-          #     python -m twine upload -r p4irin --verbose --config-file $(PYPIRC_PATH) dist/*
-          #   displayName: Upload artifacts to Azure Artifacts
+          - script: |
+              python -m twine upload -r p4irin --verbose --skip-existing --config-file $(PYPIRC_PATH) dist/*
+            displayName: Upload artifacts to Azure Artifacts
   


### PR DESCRIPTION
Continue uploading if a distribution file already exists on Azure Artifacts