### PR TITLE
Publish pytest results and coverage to Azure Pipelines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ __pycache__/
 .env
 assets/
 NOTES.md
+**/.coverage
+htmlcov/
+coverage.xml
+junit.xml
+test-output.xml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,12 +28,26 @@ stages:
             displayName: 'Use Python $(python.version)'
 
           - script: |
-              python -m pip install ".[test]"
-            displayName: 'Install dependencies'
+              python -m pip install --upgrade pip
+              python -m pip install -e ".[test]"
+            displayName: 'Install project and test dependencies'
 
           - script: |
-              python -m unittest -v tests.tests
-            displayName: 'Run unit tests'
+              python -m pytest -v --junitxml=junit.xml --cov src/c4t/ --cov-report xml tests/*
+            displayName: 'Run tests and report code coverage'
+
+          - task: PublishTestResults@2
+            condition: succeededOrFailed()
+            inputs:
+              testResultsFormat: 'JUnit'
+              testResultsFiles: './junit.xml'
+            displayName: 'Publish test results to Azure Pipelines'
+
+          - task: PublishCodeCoverageResults@2
+            condition: succeededOrFailed()
+            inputs:
+              summaryFileLocation: './coverage.xml'
+            displayName: 'Publish code coverage results to Azure Pipelines'
 
       - job: 'BuildAndUploadArtifacts'
         pool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ dev = [
 ]
 test = [
   "selenium >= 4.12.0",
+  "pytest >= 8.1.1",
+  "pytest-cov >= 4.1.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
In Azure Pipeline, use pytest to kick off tests and report on code coverage. The results of the tests and code coverage are published to Azure Pipelines