### PR TITLE
Add visual 'active' cue if a version is the active one

### DIFF
--- a/src/c4t/__init__.py
+++ b/src/c4t/__init__.py
@@ -407,7 +407,8 @@ browser.quit()
         for n, item in enumerate(items, start=0):
             if os.path.isdir(f'{self.path}/{item}'):
                 if output:
-                    print(f'{n} - {item}')
+                    active = ', active' if item == self.active_version else ''
+                    print(f'{n} - {item}{active}')
                 versions.append(item)
         return versions
     


### PR DESCRIPTION
E.g.:

(venv) $ c4t list -i
0 - 116.0.5794.0
1 - 124.0.6367.91, **_active_**
2 - 125.0.6422.14

and

(venv) $ c4t switch
0 - 116.0.5794.0, active
1 - 124.0.6367.91
2 - 125.0.6422.14
Select a version by number: