### PR TITLE
Implement --last-known-good-version for the install sub command

### DIFF
--- a/src/c4t/__init__.py
+++ b/src/c4t/__init__.py
@@ -460,3 +460,15 @@ browser.quit()
             print(f'{n} - {channel} version={version}, revision={revision}{installed}')
             versions.append(version)
         return versions
+    
+    def install_last_known_good_version(self) -> None:
+        versions = self.last_known_good_versions()
+        try:
+            selection = int(input('Select a version by number: '))
+        except ValueError:
+            selection = None
+        except IndexError:
+            selection = None
+
+        if selection is not None:
+            self.install(version=versions[selection])

--- a/src/c4t/cli.py
+++ b/src/c4t/cli.py
@@ -36,6 +36,12 @@ def cli() -> None:
         help="The version of 'Chrome for Testing' assets to install. " +
              "The default is '%(default)s'"
     )
+    sp_install.add_argument(
+        '-l',
+        '--last-known-good-version',
+        action='store_true',
+        help='Install a last known good version from a list'
+    )
 
     help_path = 'Show the installation path of assets and exit.'
     sub_parsers.add_parser(
@@ -80,8 +86,11 @@ def cli() -> None:
     args = parser.parse_args()
 
     if args.command == 'install':
-        print(f"Installing version '{args.version}'")
-        assets.install(version=args.version)
+        if args.last_known_good_version:
+            assets.install_last_known_good_version()
+        else:
+            print(f"Installing version '{args.version}'")
+            assets.install(version=args.version)
 
     if args.command == 'path':
         print(f'Path to assets: {assets.path}')


### PR DESCRIPTION
E.g:

(venv) $ c4t install -l
0 - Stable version=124.0.6367.91, revision=1274542
1 - Beta version=125.0.6422.14, revision=1287751
2 - Dev version=126.0.6439.0, revision=1292160
3 - Canary version=126.0.6449.0, revision=1293886
Select a version by number: 2